### PR TITLE
Refactor logs

### DIFF
--- a/cmd/parser/bezbukv/main.go
+++ b/cmd/parser/bezbukv/main.go
@@ -115,7 +115,7 @@ func (w *Worker) DoWork(job *Job) *Result {
 
 func main() {
 	setup := config.MustLoad()
-	lgr := logger.New(setup.Config.Log.Level, setup.Config.Log.CallerSkipFrameCount)
+	lgr := logger.New(setup.Config.Log.Level)
 	pages := 36
 	results := make(chan *Result, pages)
 	parser := ParserWithPagination(

--- a/cmd/parser/bezbukv/main.go
+++ b/cmd/parser/bezbukv/main.go
@@ -115,7 +115,7 @@ func (w *Worker) DoWork(job *Job) *Result {
 
 func main() {
 	setup := config.MustLoad()
-	lgr := logger.New(setup.Config.Log.Level, setup.Config.Log.CallerSkipFrameCount, nil)
+	lgr := logger.New(setup.Config.Log.Level, setup.Config.Log.CallerSkipFrameCount)
 	pages := 36
 	results := make(chan *Result, pages)
 	parser := ParserWithPagination(

--- a/config/config.go
+++ b/config/config.go
@@ -26,9 +26,7 @@ type (
 	}
 
 	Log struct {
-		Level                string `yaml:"level" env-default:"debug"`
-		FilePath             string `yaml:"file_path" env-required:"true"`
-		CallerSkipFrameCount int    `yaml:"caller_skip_frame_count" env-default:"3"`
+		Level string `yaml:"level" env-default:"debug"`
 	}
 
 	Env struct {

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -4,5 +4,3 @@ http_server:
   idle_timeout: 30s
 log:
   level: debug
-  file_path: tmp/log/dev.txt
-  caller_skip_frame_count: 3

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,7 +23,7 @@ import (
 
 func Run(setup *config.Setup) {
 	// Initialize logger
-	lgr := logger.New(setup.Config.Log.Level, setup.Config.Log.CallerSkipFrameCount)
+	lgr := logger.New(setup.Config.Log.Level)
 
 	// Validator
 	val, err := validator.NewValidator()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -57,8 +57,8 @@ func Run(setup *config.Setup) {
 	http.SetupRouter(httpServer.Router, setup, lgr, val, middlewares, useCases)
 
 	// Start Http Server
-	lgr.Info("app - Run - httpServer.Start")
 	httpServer.Start()
+	lgr.Info("Wordka:Start | Address: %v, Env: %v", setup.Config.HttpServer.Address, setup.Env.AppEnv)
 
 	// Waiting signal
 	interrupt := make(chan os.Signal, 1)
@@ -66,14 +66,15 @@ func Run(setup *config.Setup) {
 
 	select {
 	case s := <-interrupt:
-		lgr.Info("app - Run - signal: %s", s.String())
+		lgr.Info("Wordka:Running | Signal: %s", s.String())
 	case err = <-httpServer.Notify():
-		lgr.Error(fmt.Errorf("app - Run - httpServer.Notify: %w", err))
+		lgr.Error(fmt.Errorf("Wordka:Running | Notify: %w", err))
 	}
 
 	// Shutdown
 	err = httpServer.Shutdown()
 	if err != nil {
-		lgr.Error(fmt.Errorf("app - Run - httpServer.Shutdown: %w", err))
+		lgr.Error(fmt.Errorf("Wordka:Shutdown | Error: %w", err))
 	}
+	lgr.Info("Wordka:Shutdown")
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,18 +23,7 @@ import (
 
 func Run(setup *config.Setup) {
 	// Initialize logger
-	logFile, err := os.OpenFile(setup.Config.Log.FilePath, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666)
-	if err != nil {
-		log.Fatal().
-			Err(err).
-			Msg("could not open log file")
-	}
-	defer func(logFile *os.File) {
-		if err := logFile.Close(); err != nil {
-			log.With().Err(err)
-		}
-	}(logFile)
-	lgr := logger.New(setup.Config.Log.Level, setup.Config.Log.CallerSkipFrameCount, logFile)
+	lgr := logger.New(setup.Config.Log.Level, setup.Config.Log.CallerSkipFrameCount)
 
 	// Validator
 	val, err := validator.NewValidator()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,22 +15,18 @@ import (
 	"github.com/Markard/wordka/pkg/http/validator"
 	"github.com/Markard/wordka/pkg/logger"
 	"github.com/Markard/wordka/pkg/postgres"
-	"github.com/rs/zerolog/log"
 	"os"
 	"os/signal"
 	"syscall"
 )
 
 func Run(setup *config.Setup) {
-	// Initialize logger
 	lgr := logger.New(setup.Config.Log.Level)
 
 	// Validator
 	val, err := validator.NewValidator()
 	if err != nil {
-		log.Fatal().
-			Err(err).
-			Msg("could not initiate validator")
+		lgr.Fatal(fmt.Errorf("could not initiate validator: %w", err))
 	}
 
 	// Repository PostgreSQL

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -27,7 +27,7 @@ type Logger struct {
 
 var _ Interface = (*Logger)(nil)
 
-func New(level string, callerSkipFrameCount int) *Logger {
+func New(level string) *Logger {
 	setGlobalLevel(level)
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
@@ -35,7 +35,6 @@ func New(level string, callerSkipFrameCount int) *Logger {
 	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout}).
 		With().
 		Timestamp().
-		CallerWithSkipFrameCount(zerolog.CallerSkipFrameCount + callerSkipFrameCount).
 		Logger()
 
 	return &Logger{

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -5,7 +5,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
 	"github.com/rs/zerolog/pkgerrors"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -28,19 +27,12 @@ type Logger struct {
 
 var _ Interface = (*Logger)(nil)
 
-func New(level string, callerSkipFrameCount int, logFile *os.File) *Logger {
+func New(level string, callerSkipFrameCount int) *Logger {
 	setGlobalLevel(level)
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 
-	consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
-	var w io.Writer
-	if logFile != nil {
-		w = zerolog.MultiLevelWriter(consoleWriter, logFile)
-	} else {
-		w = zerolog.ConsoleWriter{Out: os.Stdout}
-	}
-	logger := zerolog.New(w).
+	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout}).
 		With().
 		Timestamp().
 		CallerWithSkipFrameCount(zerolog.CallerSkipFrameCount + callerSkipFrameCount).


### PR DESCRIPTION
Remove 
- Logging to local file. Stdout  is enough.
- CallerWithSkipFrameCount info. Never used it.

Improve app log information, add address and env info.
